### PR TITLE
Added database re-usability by name

### DIFF
--- a/src/EfCore.InMemoryHelpers/DatabaseReusability.cs
+++ b/src/EfCore.InMemoryHelpers/DatabaseReusability.cs
@@ -1,0 +1,8 @@
+namespace EfCore.InMemoryHelpers
+{
+    public enum DatabaseReusability
+    {
+        Active,
+        Disabled
+    }
+}

--- a/src/EfCore.InMemoryHelpers/InMemoryContextBuilder.cs
+++ b/src/EfCore.InMemoryHelpers/InMemoryContextBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
 
@@ -6,6 +7,8 @@ namespace EfCore.InMemoryHelpers
 {
     public static class InMemoryContextBuilder
     {
+        private static HashSet<string> existingDatabases = new HashSet<string>();
+        
         public static TContext Build<TContext>(bool enableSensitiveDataLogging = true)
             where TContext : DbContext
         {
@@ -20,17 +23,43 @@ namespace EfCore.InMemoryHelpers
             Guard.AgainstNull(nameof(builder), builder);
             return Build(builder, x => (TContext) Activator.CreateInstance(typeof(TContext), x));
         }
+        
+        public static TContext Build<TContext>(string databaseName, bool enableSensitiveDataLogging = true)
+            where TContext : DbContext
+        {
+            var builder = new DbContextOptionsBuilder<TContext>();
+            builder.EnableSensitiveDataLogging(enableSensitiveDataLogging);
+            return Build(builder, x => (TContext) Activator.CreateInstance(typeof(TContext), x), databaseName, DatabaseReusability.Active);
+        }
 
         public static TContext Build<TContext>(DbContextOptionsBuilder builder, Func<DbContextOptions, TContext> contextConstructor)
             where TContext : DbContext
         {
+            return Build(builder, contextConstructor, Guid.NewGuid().ToString());
+        }
+        
+        public static TContext Build<TContext>(DbContextOptionsBuilder builder, 
+            Func<DbContextOptions, TContext> contextConstructor, 
+            string databaseName, 
+            DatabaseReusability reuseOption = DatabaseReusability.Disabled)
+            where TContext : DbContext
+        {
             Guard.AgainstNull(nameof(builder), builder);
             Guard.AgainstNull(nameof(contextConstructor), contextConstructor);
-            builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            builder.UseInMemoryDatabase(databaseName);
             builder.ReplaceService<IDbContextDependencies, DbContextDependenciesEx>();
             var context = contextConstructor(builder.Options);
+            var exists = existingDatabases.Contains(databaseName);
+            if (reuseOption != DatabaseReusability.Disabled && exists) return context;
+            TrackDatabase(reuseOption, exists, databaseName);
             context.ResetValueGenerators();
             return context;
         }
+
+        private static void TrackDatabase(DatabaseReusability reuseOption, bool exists, string databaseName)
+        {
+            if (reuseOption == DatabaseReusability.Active && !exists) existingDatabases.Add(databaseName);
+        }
+        
     }
 }

--- a/src/Tests/ConcurrencyTests.cs
+++ b/src/Tests/ConcurrencyTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using ApprovalTests;
@@ -51,6 +52,29 @@ public class ConcurrencyTests : TestBase
             context.SaveChanges();
             Assert.NotEqual(firstTimestamp.GetGuid(), update.Timestamp.GetGuid());
         }
+    }
+    
+    [Fact]
+    public void ReusabilitySucceeds()
+    {
+        const string dbName = "MyDatabase";
+        const string value = "prop";
+        using (var context = InMemoryContextBuilder.Build<TestDataContext>(dbName))
+        {
+            var entity = new TestEntity
+            {
+                Property = value
+            };
+            context.Add(entity);
+            context.SaveChanges();
+        }
+
+        TestEntity res;
+        using (var context = InMemoryContextBuilder.Build<TestDataContext>(dbName))
+        {
+            res = context.TestEntities.First(e => e.Property == value);
+        }
+        Assert.NotNull(res);
     }
 
     [Fact]

--- a/src/Tests/ContextBuilderTests.cs
+++ b/src/Tests/ContextBuilderTests.cs
@@ -21,6 +21,22 @@ public class ContextBuilderTests : TestBase
             Assert.Single(item);
         }
     }
+    
+    [Fact]
+    public void GetInMemoryContextWithSpecifiedDbName()
+    {
+        using (var context = InMemoryContextBuilder.Build<TestDataContext>("MyDatabase"))
+        {
+            var entity = new TestEntity
+            {
+                Property = "prop"
+            };
+            context.Add(entity);
+            context.SaveChanges();
+            var item = context.TestEntities.ToList();
+            Assert.Single(item);
+        }
+    }
 
     public ContextBuilderTests(ITestOutputHelper output) :
         base(output)

--- a/src/Tests/Snippets/Sample.cs
+++ b/src/Tests/Snippets/Sample.cs
@@ -49,4 +49,20 @@ class Sample
         }
         #endregion
     }
+    
+    void WithDatabaseName()
+    {
+        #region withDatabaseName
+        var builder = new DbContextOptionsBuilder<MyDataContext>();
+        using (var context = InMemoryContextBuilder.Build(builder, options => new MyDataContext(options)))
+        {
+            var entity = new MyEntity
+            {
+                Property = "prop"
+            };
+            context.Add(entity);
+            context.SaveChanges();
+        }
+        #endregion
+    }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,8 +11,6 @@
     <PackageReference Include="ApprovalTests" Version="3.0.19" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.1" />
     <PackageReference Include="CaptureSnippetsSimple" Version="8.6.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="ObjectApproval" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="ApprovalTests" Version="3.0.19" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.1" />
     <PackageReference Include="CaptureSnippetsSimple" Version="8.6.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="ObjectApproval" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />


### PR DESCRIPTION
The Issue [https://github.com/aspnet/EntityFrameworkCore/issues/6872](url) prevented me from easily using the InMemory-Provider for Tests, so I stumbled upon this repo. Since I want to do multiple units of work, whereas in here only one unit of work is supported from what I've seen, I added some changes for myself. 

These include additions to track databases by name and only resetting key-generation if the name has not been used yet. Basic tests included.